### PR TITLE
Changed the way that the ServerProcessStateHandler works.

### DIFF
--- a/MCSMLauncher.csproj
+++ b/MCSMLauncher.csproj
@@ -88,6 +88,7 @@
         <Compile Include="common\background\ServerBackupHandler.cs" />
         <Compile Include="common\background\ServerProcessStateHandler.cs" />
         <Compile Include="common\caches\GlobalEditorsCache.cs" />
+        <Compile Include="common\caches\QuickAccessEditorsCache.cs" />
         <Compile Include="common\Constants.cs" />
         <Compile Include="common\factories\MappedServerTypes.cs" />
         <Compile Include="common\factories\ServerTypeMappingsFactory.cs" />

--- a/common/caches/GlobalEditorsCache.cs
+++ b/common/caches/GlobalEditorsCache.cs
@@ -57,7 +57,7 @@ namespace MCSMLauncher.common.caches
         /// </summary>
         /// <param name="serverSection">The server section to match the editor to</param>
         /// <returns>The ServerEditor matching the server name provided</returns>
-        private ServerEditor? Get(Section serverSection) =>
+        public ServerEditor? Get(Section serverSection) =>
             ServerEditorsCache.FirstOrDefault(x => x.ServerSection.SectionFullPath.Equals(serverSection.SectionFullPath));
         
         /// <summary>
@@ -65,7 +65,7 @@ namespace MCSMLauncher.common.caches
         /// </summary>
         /// <param name="serverSection">The server section to match the editor to</param>
         /// <returns>The ServerEditor instance</returns>
-        private ServerEditor Add(Section serverSection)
+        public ServerEditor Add(Section serverSection)
         {
             // Checks if the server editor already exists in the cache. If so, returns it.
             ServerEditor? editorCheck = Get(serverSection);

--- a/common/caches/QuickAccessEditorsCache.cs
+++ b/common/caches/QuickAccessEditorsCache.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using PgpsUtilsAEFC.common;
+
+namespace MCSMLauncher.common.caches
+{
+    /// <summary>
+    /// This class is meant to implement a cache to quickly access the server editors through string keys. It
+    /// should be used sparingly, since it is a bit consuming.
+    /// </summary>
+    public class QuickAccessEditorsCache
+    {
+
+        /// <summary>
+        /// The cache of server editors.
+        /// </summary>
+        public Dictionary<string, ServerEditor> Cache { get; } = new ();
+
+        /// <summary>
+        /// Main constructor for the QuickAccessEditorsCache class.
+        /// </summary>
+        public QuickAccessEditorsCache() { }
+        
+        /// <summary>
+        /// Gets the server editor from the cache. If it doesn't exist, it returns null.
+        /// </summary>
+        /// <param name="serverName">The server name bound to the editor to get from the cache</param>
+        /// <returns>A ServerEditor instance matching the server name, or null if not found</returns>
+        public ServerEditor Get(string serverName) => 
+            Cache.ContainsKey(serverName) ? Cache[serverName] : null;
+        
+        /// <summary>
+        /// Adds a server editor to the cache.
+        /// </summary>
+        /// <param name="editor">The editor to add to the cache</param>
+        public void Add(ServerEditor editor) => Cache.Add(editor.ServerSection.SimpleName, editor);
+        
+        /// <summary>
+        /// Removes a server editor from the cache.
+        /// </summary>
+        /// <param name="serverName">The server name to remove from the cache</param>
+        public void Remove(string serverName) => Cache.Remove(serverName);
+
+    }
+}

--- a/gui/Mainframe.cs
+++ b/gui/Mainframe.cs
@@ -63,11 +63,10 @@ namespace MCSMLauncher.gui
         /// </summary>
         /// <param name="sender">The event sender</param>
         /// <param name="e">The event arguments</param>
-        private async void ServersToolStripMenuItem_Click(object sender, EventArgs e)
+        private void ServersToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainLayout.Contains(ServerList.INSTANCE.GridServerList)) return;
             MainLayout.SetAllFrom(ServerList.INSTANCE.GetLayout());
-            await ServerList.INSTANCE.UpdateAllButtonStatesAsync();
         }
 
         /// <summary>

--- a/gui/ServerList.cs
+++ b/gui/ServerList.cs
@@ -235,17 +235,13 @@ namespace MCSMLauncher.gui
         /// </summary>
         public async Task UpdateAllButtonStatesAsync()
         {
-            List<Task> tasks = new ();
-
             // Iterates through all the listed servers and adds a task to update their state if they're running
             foreach (DataGridViewRow row in GridServerList.Rows)
             {
                 Section serverSection = FileSystem.GetFirstSectionNamed("servers/" + row.Cells[2].Value);
                 ServerEditor editor = GlobalEditorsCache.INSTANCE.GetOrCreate(serverSection);
-                tasks.Add(UpdateServerButtonStateAsync(editor));
+                await UpdateServerButtonStateAsync(editor);
             }
-
-            await Task.WhenAll(tasks);
         }
 
         /// <summary>


### PR DESCRIPTION
Changed the way that the ServerProcessStateHandler works so that it is the sole responsible class for handling the actual state changes on the servers.

Introduced a QuickAccessEditorsCache, used by the ServerProcessStateHandler for faster access and less clutter on the global cache.