### PR TITLE
Fixed issue18

### DIFF
--- a/Installer.nsi
+++ b/Installer.nsi
@@ -24,7 +24,7 @@
  
 !define company "MrKelpy"
  
-!define prodversion "1.3.1"
+!define prodversion "1.3.2"
 !define prodname "MCSM Launcher v${prodversion}"
 !define exec "MCSMLauncher.exe"
 

--- a/common/ServerEditor.cs
+++ b/common/ServerEditor.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using MCSMLauncher.common.models;
+using MCSMLauncher.gui;
 using MCSMLauncher.utils;
 using PgpsUtilsAEFC.common;
 using PgpsUtilsAEFC.utils;
@@ -174,14 +175,20 @@ namespace MCSMLauncher.common
             // Creates a new dictionary to store the properties.
             Dictionary<string, string> propertiesDictionary = new () { { "server-port", "25565" } };
             string propertiesPath = ServerSection.GetFirstDocumentNamed("server.properties");
-
+            
+            // Gets the keys eligible to be edited by the user through the mcsm.
+            List<string> propertiesMask = ServerEditPrompt.GetTags();
+            
             if (propertiesPath == null) return propertiesDictionary;
 
             // Reads the file line by line, and adds the key and value to the dictionary.
             foreach (string line in FileUtils.ReadFromFile(propertiesPath))
             {
                 if (line.StartsWith("#")) continue;
-                string[] splitLine = line.Split('=');
+                string[] splitLine = line.Split(new [] {"="}, 2, StringSplitOptions.None);
+                
+                // Filters out the keys that are not eligible to be edited by the user.
+                if (!propertiesMask.Contains(splitLine[0])) continue;
                 propertiesDictionary[splitLine[0]] = splitLine[1];
             }
 

--- a/common/models/ServerInformation.cs
+++ b/common/models/ServerInformation.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using MCSMLauncher.utils;
 using PgpsUtilsAEFC.common;
@@ -145,7 +146,7 @@ namespace MCSMLauncher.common.models
         public Dictionary<string, string> ToDictionary()
         {
             // The dictionary to use as the serialization dictionary
-            Dictionary<string, string> dict = new Dictionary<string, string>();
+            Dictionary<string, string> dict = new ();
 
             // Act as a serializer for the ServerInformation object, matching all the fields to the dictionary keys
             foreach (PropertyInfo field in typeof(ServerInformation).GetProperties())
@@ -153,5 +154,6 @@ namespace MCSMLauncher.common.models
 
             return dict;
         }
+        
     }
 }

--- a/gui/ServerEditPrompt.cs
+++ b/gui/ServerEditPrompt.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Windows.Forms;
 using MCSMLauncher.common;
 using PgpsUtilsAEFC.common;
@@ -61,6 +62,35 @@ namespace MCSMLauncher.gui
             }
         }
 
+        /// <summary>
+        /// Constructor for the ServerEditPrompt form. Used to build the fields of the form.
+        /// </summary>
+        private ServerEditPrompt()
+        {
+            InitializeComponent();
+        }
+
+        /// <summary>
+        /// Returns a list of all the tags that are used in the editor.
+        /// These correspond to the names of the keys in the server.properties file.
+        /// </summary>
+        /// <returns>List(String) of all the tags in lowercase</returns>
+        public static List<string> GetTags()
+        {
+            List<string> tags = new();
+
+            // Gets all the tags from the fields in the ServerEditPrompt class filtering out empty ones
+            foreach (FieldInfo field in typeof(ServerEditPrompt).GetFields(BindingFlags.NonPublic | BindingFlags.Instance))
+            {
+                Control control = field.GetValue(new ServerEditPrompt()) as Control;
+                if (control?.Tag == null || control.Tag.ToString() == string.Empty) continue;
+
+                tags.Add(control.Tag.ToString());
+            }
+            
+            return tags;
+        }
+        
         /// <summary>
         /// Switches the focus to the first label in the form when the form is loaded, so that nothing
         /// is selected.


### PR DESCRIPTION
Added a property mask to avoid caching unecessary properties from the server.properties file
Added a GetTags method for that mask
Changed the parsing method for the LoadProperties method, now the splitting will only happen for the first '='